### PR TITLE
Minor usage improvements

### DIFF
--- a/PHFRefreshControl.h
+++ b/PHFRefreshControl.h
@@ -2,18 +2,21 @@
 
 @interface PHFRefreshControl : UIControl
 
-// Designated initializer.
-- (id)init;
-
 @property (nonatomic, strong) UIColor *tintColor;
-
+@property (nonatomic, copy) void (^refreshBlock)(void);
 @property (nonatomic, readonly, getter=isRefreshing) BOOL refreshing;
 
+- (id)initWithTintColor:(UIColor *)tintColor;
 - (void)beginRefreshing;
 - (void)endRefreshing;
 
 @end
 
 @interface UIScrollView (PHFRefreshControl)
+
 @property (nonatomic, strong) PHFRefreshControl *refreshControl;
+
+- (PHFRefreshControl *)setRefreshControlWithTarget:(id)target action:(SEL)action;
+- (PHFRefreshControl *)setRefreshControlWithRefreshBlock:(void (^)(void))refreshBlock;
+
 @end

--- a/PHFRefreshControl.m
+++ b/PHFRefreshControl.m
@@ -16,14 +16,27 @@ static NSTimeInterval const kAnimationDuration = 0.25;
 
 @implementation PHFRefreshControl
 
+- (id)initWithTintColor:(UIColor *)tintColor {
+    self = [self init];
+    
+    if (self) {
+        self.tintColor = tintColor;
+    }
+    
+    return self;
+}
+
 - (id)init {
     self = [super initWithFrame:CGRectMake(0, 0, 100, kViewHeight)];
-    [self setAutoresizingMask:UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleBottomMargin];
+    
+    if (self) {
+        [self setAutoresizingMask:UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleBottomMargin];
 
-    [[self layer] setAnchorPoint:CGPointMake(0, 1)];
+        [[self layer] setAnchorPoint:CGPointMake(0, 1)];
 
-    [self addSubview:[self arrowImageView]];
-    [self addSubview:[self activityIndicatorView]];
+        [self addSubview:[self arrowImageView]];
+        [self addSubview:[self activityIndicatorView]];
+    }
 
     return self;
 }
@@ -251,6 +264,9 @@ static NSTimeInterval const kAnimationDuration = 0.25;
 
         if (stretchFactor > kMaxStretchFactor) {
             [self sendActionsForControlEvents:UIControlEventValueChanged];
+            if (_refreshBlock)
+                _refreshBlock();
+            
             [self beginRefreshing];
         } else {
             [[self layer] setAffineTransform:transform];
@@ -274,6 +290,22 @@ static char kRefreshControlKey;
 
 - (PHFRefreshControl *)refreshControl {
     return objc_getAssociatedObject(self, &kRefreshControlKey);
+}
+
+- (PHFRefreshControl *)setRefreshControlWithTarget:(id)target action:(SEL)action {
+    PHFRefreshControl *refreshControl = [[PHFRefreshControl alloc] init];
+    [refreshControl addTarget:target action:action forControlEvents:UIControlEventValueChanged];
+    [self setRefreshControl:refreshControl];
+    
+    return refreshControl;
+}
+
+- (PHFRefreshControl *)setRefreshControlWithRefreshBlock:(void (^)(void))refreshBlock {
+    PHFRefreshControl *refreshControl = [[PHFRefreshControl alloc] init];
+    [refreshControl setRefreshBlock:refreshBlock];
+    [self setRefreshControl:refreshControl];
+    
+    return refreshControl;
 }
 
 @end


### PR DESCRIPTION
#### Allow creating passing tint color

```
PHFRefreshControl *refreshControl = [[PHFRefreshControl alloc] initWithTintColor:tintColor];
```
#### Adds notification by block

```
[refreshControl setRefreshBlock:^{
    //some code
}];
```
#### Refresh control creating directly from UIScrollView (category)

```
[scrollView setRefreshControlWithTarget:dataController action:@selector(reload)]
```

or

```
[scrollView setRefreshControlWithRefreshBlock:^{
    //some code
}];
```
